### PR TITLE
Implement monthly summaries and expense categories

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,6 +38,7 @@
         <div class="mb-2"><label class="form-label">Bedrag</label><input type="number" id="transAmount" class="form-control"></div>
         <div class="mb-2"><label class="form-label">Type</label><select id="transType" class="form-select"><option value="" disabled selected>Kies type...</option><option value="inkomen">Inkomen</option><option value="uitgave">Uitgave</option></select></div>
         <div id="incomeSubTypeWrapper" class="mb-2" style="display:none;"><label class="form-label">Soort Inkomen</label><select id="incomeSubType" class="form-select"><option value="salaris">Salaris</option><option value="terugbetaling">Terugbetaling</option><option value="uitkering">Uitkering</option><option value="bijbaan">Bijbaan</option><option value="overig">Overig</option></select></div>
+        <div id="expenseSubTypeWrapper" class="mb-2" style="display:none;"><label class="form-label">Soort Uitgave</label><select id="expenseSubType" class="form-select"><option value="SimKaart">SimKaart</option><option value="Internet/tv">Internet/tv</option><option value="Boodschappen">Boodschappen</option><option value="autoverzekering">Autoverzekering</option><option value="andere">Andere</option></select></div>
         <div class="mb-2"><label class="form-label">Rekening</label><select id="transAccount" class="form-select"></select></div>
         <div class="form-check"><input class="form-check-input" type="checkbox" id="transRecurring"><label class="form-check-label">Automatische incasso</label></div>
       </div>

--- a/style.css
+++ b/style.css
@@ -5,3 +5,6 @@ body { background-color: #121212; color: #fff; }
 .positive { background-color: #4caf5033; }
 .modal-content { background-color: #1e1e1e; color: white; }
 .form-control, .form-select { background-color: #2c2c2c; color: white; border: 1px solid #555; }
+.btn-close { filter: invert(1); }
+#newAccountName::placeholder,
+#newAccountBalance::placeholder { color: lightgray; }


### PR DESCRIPTION
## Summary
- show all months in navigation
- add expense subtypes
- show account, salary and expense totals per month
- compute yearly start balances
- tweak styles for close button and placeholders

## Testing
- `node -e "require('./script.js');"` *(fails: ReferenceError: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_685d7a4ca93c83299c29cf2fa939a70b