### PR TITLE
Fix saldo calculation and new recurring types

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,7 +40,7 @@
         <div id="incomeSubTypeWrapper" class="mb-2" style="display:none;"><label class="form-label">Soort Inkomen</label><select id="incomeSubType" class="form-select"><option value="salaris">Salaris</option><option value="terugbetaling">Terugbetaling</option><option value="uitkering">Uitkering</option><option value="bijbaan">Bijbaan</option><option value="overig">Overig</option></select></div>
         <div id="expenseSubTypeWrapper" class="mb-2" style="display:none;"><label class="form-label">Soort Uitgave</label><select id="expenseSubType" class="form-select"><option value="SimKaart">SimKaart</option><option value="Internet/tv">Internet/tv</option><option value="Boodschappen">Boodschappen</option><option value="autoverzekering">Autoverzekering</option><option value="andere">Andere</option></select></div>
         <div class="mb-2"><label class="form-label">Rekening</label><select id="transAccount" class="form-select"></select></div>
-        <div class="form-check"><input class="form-check-input" type="checkbox" id="transRecurring"><label class="form-check-label">Automatische incasso</label></div>
+        <div class="mb-2"><label class="form-label">Herhaling</label><select id="transRecurring" class="form-select"><option value="none">Geen</option><option value="monthly">Maandelijks</option><option value="weekly">Wekelijks</option><option value="yearly">Jaarlijks</option></select></div>
       </div>
       <div class="modal-footer">
         <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Annuleer</button>


### PR DESCRIPTION
## Summary
- fix running balance by computing month-end totals per month
- show monthly/weekly/yearly recurrence options in form
- replicate recurring transactions up to current month
- highlight salary difference in red when negative and green otherwise

## Testing
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_685d7dec0368832982f4e9e489dd5006