### PR TITLE
Enable drag and drop plus transaction delete

### DIFF
--- a/style.css
+++ b/style.css
@@ -10,3 +10,6 @@ body { background-color: #121212; color: #fff; }
 #newAccountBalance::placeholder,
 #newPotName::placeholder,
 #newPotBalance::placeholder { color: lightgray; }
+
+.draggable { cursor: move; }
+.drag-over { outline: 2px dashed #888; }


### PR DESCRIPTION
## Summary
- make account, pot and transaction rows draggable
- add remove transaction button
- highlight items while dragging

## Testing
- `node -c script.js`
- `npx eslint script.js` *(fails: ESLint config missing)*

------
https://chatgpt.com/codex/tasks/task_e_685eff09e3a8832994de16d4e335a207